### PR TITLE
DAN-30: 피드 도메인 모델에 작성자, 타이틀 프로퍼티 추가 & AbsctractDocument에서 Document 상속 제거

### DIFF
--- a/src/common/abstract.schema.ts
+++ b/src/common/abstract.schema.ts
@@ -1,8 +1,8 @@
 import { Prop, Schema } from "@nestjs/mongoose"
-import { Document, SchemaTypes, Types } from "mongoose"
+import { SchemaTypes, Types } from "mongoose"
 
 @Schema()
-export class AbstractDocument extends Document {
+export abstract class AbstractDocument {
   @Prop({ type: SchemaTypes.ObjectId })
   _id: Types.ObjectId
 }

--- a/src/feed/feed-post.dto.ts
+++ b/src/feed/feed-post.dto.ts
@@ -5,7 +5,7 @@ import { Location } from "./location.type"
 export class FeedPostRequest {
   @IsNotEmpty()
   @Type(() => String)
-  name: string
+  title: string
   @IsNotEmpty()
   @MaxLength(500)
   @Type(() => String)

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -8,6 +8,7 @@ import {
   UseInterceptors,
 } from "@nestjs/common"
 import { FileFieldsInterceptor } from "@nestjs/platform-express"
+import { Types } from "mongoose"
 import { MultiImageFileValidationPipe } from "src/infra/file/file.multiImageFileValidation.pipe"
 import { FeedPostRequest } from "./feed-post.dto"
 import { FeedService } from "./feed.service"
@@ -31,7 +32,11 @@ export class FeedController {
     @UploadedFiles(new MultiImageFileValidationPipe())
     files: { files: Express.Multer.File[] },
   ): Promise<any> {
-    const created = await this.feedService.postFeed(req, files.files)
+    const created = await this.feedService.postFeed(
+      Types.ObjectId.createFromTime(1),
+      req,
+      files.files,
+    )
     return { _id: created }
   }
 }

--- a/src/feed/feed.entity.ts
+++ b/src/feed/feed.entity.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose"
-import { HydratedDocument } from "mongoose"
+import { HydratedDocument, Types } from "mongoose"
 import { AbstractDocument } from "src/common/abstract.schema"
 import { requireArgument } from "src/common/validation-utils"
 import { Photo } from "../common/photo.model"
@@ -10,7 +10,9 @@ export type FeedDocument = HydratedDocument<Feed>
 @Schema()
 export class Feed extends AbstractDocument {
   @Prop({ required: true })
-  name: string
+  userId: Types.ObjectId
+  @Prop({ required: true })
+  title: string
   @Prop()
   photos: Photo[]
   @Prop({ required: true })
@@ -27,7 +29,8 @@ export class Feed extends AbstractDocument {
   expenses?: number
 
   constructor(
-    name: string,
+    userId: Types.ObjectId,
+    title: string,
     content: string,
     tag: string[],
     date: string,
@@ -40,9 +43,9 @@ export class Feed extends AbstractDocument {
       photos != undefined ? location != undefined : true,
       "사진을 첨부한 경우 위치를 입력해야 합니다.",
     )
-
     super()
-    this.name = name
+    this.userId = userId
+    this.title = title
     this.photos = photos
     this.content = content
     this.tag = tag

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -3,17 +3,20 @@ import { FeedPostRequest } from "./feed-post.dto"
 import { Feed } from "./feed.entity"
 import { FeedRepository } from "./feed.repository"
 import { Photo } from "../common/photo.model"
+import { Types } from "mongoose"
 
 @Injectable()
 export class FeedService {
   constructor(private readonly feedRepository: FeedRepository) {}
 
   async postFeed(
+    userId: Types.ObjectId,
     req: FeedPostRequest,
     files: Express.Multer.File[],
   ): Promise<string> {
     const feed: Feed = new Feed(
-      req.name,
+      userId,
+      req.title,
       req.content,
       req.tag,
       req.date,
@@ -22,7 +25,6 @@ export class FeedService {
       req.expenses,
       req.location,
     )
-
     const saved = await this.feedRepository.create(feed)
 
     return saved._id.toString()

--- a/test/feed/feed-post.dto.spec.ts
+++ b/test/feed/feed-post.dto.spec.ts
@@ -20,7 +20,7 @@ describe("FeedPostDto", () => {
     try {
       await validationPipe.transform(
         <FeedPostRequest>{
-          name: "",
+          title: "",
           content: "",
           date: "",
           tag: ["tag1", "tag2"],
@@ -30,7 +30,7 @@ describe("FeedPostDto", () => {
     } catch (err) {
       expect(err.getResponse().statusCode).toBe(400)
       expect(err.getResponse().message).toStrictEqual([
-        "name should not be empty",
+        "title should not be empty",
         "content should not be empty",
         "date must be a valid ISO 8601 date string",
         "date should not be empty",
@@ -44,7 +44,7 @@ describe("FeedPostDto", () => {
     try {
       await validationPipe.transform(
         <FeedPostRequest>{
-          name: "test",
+          title: "test",
           content: generate(501),
           tag: ["test"],
           date: "2020-12-12",
@@ -65,7 +65,7 @@ describe("FeedPostDto", () => {
     try {
       await validationPipe.transform(
         <FeedPostRequest>{
-          name: "test",
+          title: "test",
           content: "content",
           tag: ["test"],
           date: "zzz",

--- a/test/feed/feed.e2e-spec.ts
+++ b/test/feed/feed.e2e-spec.ts
@@ -40,7 +40,7 @@ describe("Feed", () => {
     return request(app.getHttpServer())
       .post("/feeds")
       .send({
-        name: "test",
+        title: "test",
         content: "content",
         tag: "tag1",
         date: "2020-12-12",

--- a/test/feed/feed.entity.spec.ts
+++ b/test/feed/feed.entity.spec.ts
@@ -1,3 +1,4 @@
+import { Types } from "mongoose"
 import { Photo } from "src/common/photo.model"
 import { Feed } from "src/feed/feed.entity"
 
@@ -5,7 +6,8 @@ describe("Feed Entity", () => {
   describe("post", () => {
     it("should throw IllegalArgumentException if photos exists, but location does not exist", async () => {
       const input = {
-        name: "name",
+        userId: Types.ObjectId.createFromTime(1),
+        title: "title",
         content: "content",
         tag: ["tag1", "tag2"],
         date: "2020-12-12",
@@ -16,7 +18,8 @@ describe("Feed Entity", () => {
       expect(
         () =>
           new Feed(
-            input.name,
+            input.userId,
+            input.title,
             input.content,
             input.tag,
             input.date,

--- a/test/feed/feed.service.spec.ts
+++ b/test/feed/feed.service.spec.ts
@@ -28,8 +28,9 @@ describe("FeedService", () => {
   })
   it("post", async () => {
     const req: FeedPostRequest = new FeedPostRequest()
+    const userId = Types.ObjectId.createFromTime(1)
 
-    req.name = "name"
+    req.title = "title"
     req.content = "content"
     req.date = "2020-12-12"
     req.location = {
@@ -56,7 +57,7 @@ describe("FeedService", () => {
       buffer: undefined,
     }
 
-    await feedService.postFeed(req, [file])
+    await feedService.postFeed(userId, req, [file])
 
     expect(mockCreatefn).toBeCalled()
   })


### PR DESCRIPTION
- 피드 도메인 모델에 작성자, 타이틀 프로퍼티 추가
- AbsctractDocument에서 Document 상속 제거 (super() 호출 시 오류 발생으로 인해)